### PR TITLE
Add visits and events metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,24 +189,24 @@ To know more about properties, see [Plausible Docs: Filtering](https://plausible
 Metrics are aggregate information about the data. All queries have the option for you to choose the metrics you want to
 see included in the results.
 
-There are 4 metrics currently that you can ask the results for: number of visitors, number of page views, visit duration
-and bounce rate. In this library, these metrics are represented by
+There are 6 metrics currently that you can ask the results for: number of visitors, number of page views, visit duration, bounce rate, visits and events.
+In this library, these metrics are represented by
 the [Metric](https://pkg.go.dev/github.com/andrerfcsantos/go-plausible/plausible#Metric)
-type. There are 4 constants of type `Metric`, each one representing one of the 4 metrics: `Visitors`,
-`PageViews`, `BounceRate` and `VisitDuration`.
+type. There are 6 constants of type `Metric`, each one representing one of the 6 metrics: `Visitors`,
+`PageViews`, `BounceRate`, `VisitDuration`, `Events` and `Visits`
 
 For instance, if for a query you only want information about the pageviews and number of visitors, you can pass this to
 the query in the metrics parameter:
 
 ```go
 metrics := plausible.Metrics {
-plausible.Visitors,
-plausible.PageViews,
+	plausible.Visitors,
+	plausible.PageViews,
 },
 ```
 
 For convenience, when you want to get information about all metrics, there's a function `AllMetrics()`
-that returns all the 4 metrics. However, please note that not all queries support requests for all metrics. For that
+that returns all the 6 metrics. However, please note that not all queries support requests for all metrics. For that
 reason, use requests for all metrics with caution. If you try to use a metric in a query that does not support that
 metric, you will get an error message saying which property was at fault.
 

--- a/plausible/aggregate_query.go
+++ b/plausible/aggregate_query.go
@@ -65,10 +65,10 @@ type AggregateResult struct {
 	PageviewsChange int `json:"pageviews_change"`
 
 	// VisitDuration represents the visit duration result for the query.
-	// Only use this field if you included the Visit metric in your query
+	// Only use this field if you included the VisitDuration metric in your query
 	VisitDuration float64 `json:"visit_duration"`
 	// VisitDurationChange represents the visit duration change compared to the previous period.
-	// Only use this field if you included the Visit metric in your query and ComparePreviousPeriod was set to true.
+	// Only use this field if you included the VisitVisitDuration metric in your query and ComparePreviousPeriod was set to true.
 	VisitDurationChange float64 `json:"visit_duration_change"`
 
 	// Visitors represents the number of visitors result for the query.
@@ -77,6 +77,20 @@ type AggregateResult struct {
 	// VisitorsChange represents the change in the number of visitors compared to the previous period.
 	// Only use this field if you included the Visitors metric in your query and ComparePreviousPeriod was set to true.
 	VisitorsChange int `json:"visitors_change"`
+
+	// Visits represents the visits result for the query.
+	// Only use this field if you included the Visits metric in your query
+	Visits int `json:"visits"`
+	// VisitsChange represents the visits change compared to the previous period.
+	// Only use this field if you included the Visits metric in your query and ComparePreviousPeriod was set to true.
+	VisitsChange int `json:"visits_change"`
+
+	// Events represents the events result for the query.
+	// Only use this field if you included the Events metric in your query
+	Events int `json:"events"`
+	// EventsChange represents the events change compared to the previous period.
+	// Only use this field if you included the Events metric in your query and ComparePreviousPeriod was set to true.
+	EventsChange int `json:"events_change"`
 }
 
 type rawAggregateResult struct {
@@ -85,6 +99,10 @@ type rawAggregateResult struct {
 			Change float64 `json:"change"`
 			Value  float64 `json:"value"`
 		} `json:"bounce_rate,omitempty"`
+		Events struct {
+			Change int `json:"change"`
+			Value  int `json:"value"`
+		} `json:"events,omitempty"`
 		Pageviews struct {
 			Change int `json:"change"`
 			Value  int `json:"value"`
@@ -97,6 +115,10 @@ type rawAggregateResult struct {
 			Change int `json:"change"`
 			Value  int `json:"value"`
 		} `json:"visitors,omitempty"`
+		Visits struct {
+			Change int `json:"change"`
+			Value  int `json:"value"`
+		} `json:"visits,omitempty"`
 	} `json:"results,omitempty"`
 }
 
@@ -107,17 +129,23 @@ func (r *rawAggregateResult) toAggregateResult() AggregateResult {
 		return res
 	}
 
+	res.BounceRate = r.Result.BounceRate.Value
+	res.BounceRateChange = r.Result.BounceRate.Change
+
+	res.Events = r.Result.Events.Value
+	res.EventsChange = r.Result.Events.Change
+
 	res.Pageviews = r.Result.Pageviews.Value
 	res.PageviewsChange = r.Result.Pageviews.Change
+
+	res.VisitDuration = r.Result.VisitDuration.Value
+	res.VisitDurationChange = r.Result.VisitDuration.Change
 
 	res.Visitors = r.Result.Visitors.Value
 	res.VisitorsChange = r.Result.Visitors.Change
 
-	res.BounceRate = r.Result.BounceRate.Value
-	res.BounceRateChange = r.Result.BounceRate.Change
-
-	res.VisitDuration = r.Result.VisitDuration.Value
-	res.VisitDurationChange = r.Result.VisitDuration.Change
+	res.Visits = r.Result.Visits.Value
+	res.VisitsChange = r.Result.Visits.Change
 
 	return res
 }

--- a/plausible/aggregate_query_test.go
+++ b/plausible/aggregate_query_test.go
@@ -69,7 +69,7 @@ func TestUnitToQueryArgsAggregateQuery(t *testing.T) {
 			expectedQueryArgs: QueryArgs{
 				QueryArg{Name: "period", Value: "custom"},
 				QueryArg{Name: "date", Value: "2021-01-01,2021-02-01"},
-				QueryArg{Name: "metrics", Value: "visitors,pageviews,bounce_rate,visit_duration"},
+				QueryArg{Name: "metrics", Value: "visitors,pageviews,bounce_rate,visit_duration,visits"},
 				QueryArg{Name: "filters", Value: "visit:os==Windows;event:page==/"},
 				QueryArg{Name: "compare", Value: "previous_period"},
 			},

--- a/plausible/breakdown_query_test.go
+++ b/plausible/breakdown_query_test.go
@@ -72,7 +72,7 @@ func TestUnitToQueryArgsBreakdownQuery(t *testing.T) {
 			expectedQueryArgs: QueryArgs{
 				QueryArg{Name: "property", Value: "visit:browser"},
 				QueryArg{Name: "period", Value: "day"},
-				QueryArg{Name: "metrics", Value: "visitors,pageviews,bounce_rate,visit_duration"},
+				QueryArg{Name: "metrics", Value: "visitors,pageviews,bounce_rate,visit_duration,visits"},
 				QueryArg{Name: "limit", Value: "1"},
 				QueryArg{Name: "page", Value: "1"},
 				QueryArg{Name: "filters", Value: "visit:os==Windows;event:page==/"},

--- a/plausible/metrics.go
+++ b/plausible/metrics.go
@@ -15,6 +15,10 @@ const (
 	BounceRate = Metric("bounce_rate")
 	// VisitDuration represents the visit duration metric
 	VisitDuration = Metric("visit_duration")
+	// Visits represents the number of visits/sessions metric
+	Visits = Metric("visits")
+	// Events represents the number of events (pageviews + custom events) metric
+	Events = Metric("events")
 )
 
 // AllMetrics is an utility function that returns all the metrics.
@@ -22,7 +26,7 @@ const (
 // However, please note that querying all metrics is not allowed in all type of queries.
 func AllMetrics() Metrics {
 	return Metrics{
-		Visitors, PageViews, BounceRate, VisitDuration,
+		Visitors, PageViews, BounceRate, VisitDuration, Visits,
 	}
 }
 

--- a/plausible/timeseries_query_test.go
+++ b/plausible/timeseries_query_test.go
@@ -63,7 +63,7 @@ func TestUnitToQueryArgsTimeseriesQuery(t *testing.T) {
 			expectedQueryArgs: QueryArgs{
 				QueryArg{Name: "period", Value: "day"},
 				QueryArg{Name: "filters", Value: "visit:os==Windows"},
-				QueryArg{Name: "metrics", Value: "visitors,pageviews,bounce_rate,visit_duration"},
+				QueryArg{Name: "metrics", Value: "visitors,pageviews,bounce_rate,visit_duration,visits"},
 				QueryArg{Name: "interval", Value: "date"},
 			},
 			isValid: true,


### PR DESCRIPTION
The `visits` and `events` metrics are missing: https://plausible.io/docs/stats-api#metrics

I added the `Visits` metrics to the `AllMetrics`, but not the `events` one as it's not available on the `timeseries` API: https://plausible.io/docs/stats-api#get-apiv1statstimeseries