### PR TITLE
Add the visits field to MetricsResult

### DIFF
--- a/plausible/timeseries_query.go
+++ b/plausible/timeseries_query.go
@@ -79,6 +79,10 @@ type MetricsResult struct {
 	// Visitors contains information about the number of visitors.
 	// This field must only be used if the query requested the visitors metric.
 	Visitors int `json:"visitors"`
+
+	// Visits contains information about the number of visits per session.
+	// This field must only be used if the query requested the visits metric.
+	Visits int `json:"visits"`
 }
 
 // BounceRate returns the bounce rate associated with this result.


### PR DESCRIPTION
The timeseries result was missing the `visits` field.